### PR TITLE
Fixed escaping in regexes using raw strings.

### DIFF
--- a/extension-files/tools/zabbix_check_smartmontools
+++ b/extension-files/tools/zabbix_check_smartmontools
@@ -64,7 +64,7 @@ def get_attribute(device, attribute):
     #   1 Raw_Read_Error_Rate     0x000a   100   100   000    Old_age   Always       -       0
     for line in out.decode('utf8').splitlines():
         if attribute == "Temperature_Celsius":
-            line = re.sub("\(Min\/Max \d+\/\d+\)", "", line) 
+            line = re.sub(r"\(Min\/Max \d+\/\d+\)", "", line)
 
         m = re.match(r"^\s*\d+\s+([^\s]+?)\s+0x.*\s+(([^\s]+))\s*$", line)
         if not m:

--- a/extension-files/tools/zabbix_discovery_devices
+++ b/extension-files/tools/zabbix_discovery_devices
@@ -64,9 +64,9 @@ def read_config(config_file):
             content = fh.read()
 
             # Remove multiline comments
-            content = re.sub('^\s*/\*.*?\*/\s*', '', content, 0, re.DOTALL | re.MULTILINE)
+            content = re.sub(r'^\s*/\*.*?\*/\s*', '', content, 0, re.DOTALL | re.MULTILINE)
             # Remove single line comments
-            content = re.sub('^\s*//.*$\n', '', content, 0, re.MULTILINE)
+            content = re.sub(r'^\s*//.*$'+'\n', '', content, 0, re.MULTILINE)
 
             config = json.loads(content)
 

--- a/extension-files/tools/zabbix_discovery_filesystems
+++ b/extension-files/tools/zabbix_discovery_filesystems
@@ -30,7 +30,7 @@ config_default = {
     "regex_includes_type": [".*"],
     "regex_excludes_name": [],
     "regex_excludes_type": ["nfs", "nfs4", "nfsd", "cifs", "autofs", "binfmt_misc", "cgroup", "cgroup2", "configfs",
-                            "debugfs", "overlay", "overlay2","systemd-1", "nsfs", "lxcfs", 
+                            "debugfs", "overlay", "overlay2","systemd-1", "nsfs", "lxcfs",
                             "devpts", "devtmpfs", "efivarfs", "fusectl", "fuse.gvfsd-fuse", "hugetlbfs", "mqueue",
                             "fuse.lxcfs", "xenfs", "rpc_pipefs", "efivarfs", "tracefs", "squashfs",
                             "proc", "pstore", "securityfs", "sysfs", "tmpfs", "vfat", "iso9660" ],
@@ -45,7 +45,7 @@ def check_match(matchfor, filesystem_name, config, key):
 
     if key in config:
         regexes = config[key]
-    else: 
+    else:
         regexes = []
 
     for regex in regexes:
@@ -67,9 +67,9 @@ def read_config(config_file):
             content = fh.read()
 
             # Remove multiline comments
-            content = re.sub('^\s*/\*.*?\*/\s*', '', content, 0, re.DOTALL | re.MULTILINE)
+            content = re.sub(r'^\s*/\*.*?\*/\s*', '', content, 0, re.DOTALL | re.MULTILINE)
             # Remove single line comments
-            content = re.sub('^\s*//.*$\n', '', content, 0, re.MULTILINE)
+            content = re.sub(r'^\s*//.*$'+'\n', '', content, 0, re.MULTILINE)
 
             config = json.loads(content)
 


### PR DESCRIPTION
Fixes #44.
I have only tested the `Custom - OS - Linux - Hardware` template.