### PR TITLE
Added discovery data of the original `vfs.dev.discovery`.

### DIFF
--- a/extension-files/tools/zabbix_discovery_devices
+++ b/extension-files/tools/zabbix_discovery_devices
@@ -243,17 +243,30 @@ for filename in glob.glob('/sys/block/*'):
         for smartarg in config["smartctl_subdevices"][device_name]:
             device = {}
             device['{#BLOCKDEVICE}'] = device_name + " " + smartarg
+            device['{#DEVNAME}'] = device_name + " " + smartarg
+            device['{#DEVTYPE}'] = "disk"
             devices_discovered['data'].append(device)
     elif args.software_raid:
         if raid_disks_level:
             device = {}
             device['{#BLOCKDEVICE}'] = device_name
+            device['{#DEVNAME}'] = device_name
+            device['{#DEVTYPE}'] = "disk"
             device['{#RAIDLEVEL}'] = raid_disks_level.upper()
             devices_discovered['data'].append(device)
     else:
         device = {}
         device['{#BLOCKDEVICE}'] = device_name
+        device['{#DEVNAME}'] = device_name
+        device['{#DEVTYPE}'] = "disk"
         devices_discovered['data'].append(device)
+
+for filename in glob.glob('/sys/block/*/*/partition'):
+    partition = os.path.basename(os.path.dirname(filename))
+    device = {}
+    device['{#DEVNAME}'] = partition
+    device['{#DEVTYPE}'] = "partition"
+    devices_discovered['data'].append(device)
 
 if args.debug:
     print(json.dumps(devices_discovered, sort_keys=True, indent=2))

--- a/zabbix_templates/6.4/custom-os-linux-disk-io-details.xml
+++ b/zabbix_templates/6.4/custom-os-linux-disk-io-details.xml
@@ -24,6 +24,15 @@
                     <type>ZABBIX_ACTIVE</type>
                     <key>vfs.dev.discovery.detail</key>
                     <delay>60m</delay>
+                    <filter>
+                        <conditions>
+                            <condition>
+                                <macro>{#BLOCKDEVICE}</macro>
+                                <value>.+</value>
+                                <formulaid>A</formulaid>
+                            </condition>
+                        </conditions>
+                    </filter>
                     <lifetime>14d</lifetime>
                     <item_prototypes>
                         <item_prototype>

--- a/zabbix_templates/6.4/custom-os-linux-disk-io-details.xml
+++ b/zabbix_templates/6.4/custom-os-linux-disk-io-details.xml
@@ -28,7 +28,7 @@
                         <conditions>
                             <condition>
                                 <macro>{#BLOCKDEVICE}</macro>
-                                <value>.+</value>
+                                <operator>EXISTS</operator>
                                 <formulaid>A</formulaid>
                             </condition>
                         </conditions>

--- a/zabbix_templates/6.4/custom-os-linux-hardware.xml
+++ b/zabbix_templates/6.4/custom-os-linux-hardware.xml
@@ -29,7 +29,7 @@
                         <conditions>
                             <condition>
                                 <macro>{#BLOCKDEVICE}</macro>
-                                <value>.*</value>
+                                <operator>EXISTS</operator>
                                 <formulaid>A</formulaid>
                             </condition>
                         </conditions>

--- a/zabbix_templates/6.4/custom-os-linux.xml
+++ b/zabbix_templates/6.4/custom-os-linux.xml
@@ -39,7 +39,7 @@
                             <expression>count(/Custom - OS - Linux/agent.ping,#3,&quot;eq&quot;,&quot;0&quot;)=3</expression>
                             <name>Zabbix Agent Ping</name>
                             <priority>HIGH</priority>
-                            <description>Zabbix agent does not respond to a ping request in the last two calls or no information about 
+                            <description>Zabbix agent does not respond to a ping request in the last two calls or no information about
  agent-status is received in the last 30 minutes.</description>
                         </trigger>
                         <trigger>
@@ -232,11 +232,11 @@ This trigger does not recover automatically, to get rid of this trigger, you hav
                             <priority>AVERAGE</priority>
                             <description>Check if there are failed fiberchannel paths. Check zabbix_agent log, dmesg or &quot;multipath -ll&quot; to verify.
  Status &quot;ERROR&quot; is reported if one or more paths are not ok.
- 
- example output: 
- &quot;OK: L:6,P:15,B0&quot; 
- &quot;ERROR: L:6,P:15,B2&quot; 
- 
+
+ example output:
+ &quot;OK: L:6,P:15,B0&quot;
+ &quot;ERROR: L:6,P:15,B2&quot;
+
  L: Number of LUNS
  P: Number of paths
  B: Number of failed paths</description>
@@ -1573,6 +1573,15 @@ Remove the flagfile if you decide that no reboot is required (/var/run/reboot-re
                     <name>Software RAID discovery</name>
                     <key>vfs.dev.discovery.softwareraid</key>
                     <delay>1h</delay>
+                    <filter>
+                        <conditions>
+                            <condition>
+                                <macro>{#BLOCKDEVICE}</macro>
+                                <value>.+</value>
+                                <formulaid>A</formulaid>
+                            </condition>
+                        </conditions>
+                    </filter>
                     <lifetime>14d</lifetime>
                     <item_prototypes>
                         <item_prototype>

--- a/zabbix_templates/6.4/custom-os-linux.xml
+++ b/zabbix_templates/6.4/custom-os-linux.xml
@@ -1418,7 +1418,7 @@ Remove the flagfile if you decide that no reboot is required (/var/run/reboot-re
                         <conditions>
                             <condition>
                                 <macro>{#BLOCKDEVICE}</macro>
-                                <value>^.*</value>
+                                <operator>EXISTS</operator>
                                 <formulaid>A</formulaid>
                             </condition>
                         </conditions>
@@ -1577,7 +1577,7 @@ Remove the flagfile if you decide that no reboot is required (/var/run/reboot-re
                         <conditions>
                             <condition>
                                 <macro>{#BLOCKDEVICE}</macro>
-                                <value>.+</value>
+                                <operator>EXISTS</operator>
                                 <formulaid>A</formulaid>
                             </condition>
                         </conditions>


### PR DESCRIPTION
Fixes #46, more context there.
I added the filter which checks if `{#BLOCKDEVICE}` is not empty to the `Software RAID discovery` and `Disk IO detail discovery`. The other discoveries did already have this filter.