### PR TITLE
Fixed hardware.disk.smart.info key not consistent

### DIFF
--- a/extension-files/agent-config/zabbix_smartmontools.conf
+++ b/extension-files/agent-config/zabbix_smartmontools.conf
@@ -3,5 +3,5 @@ UserParameter=vfs.dev.discovery.smart,/usr/bin/zabbix_discovery_devices --config
 #
 UserParameter=hardware.disk.health[*],sudo /usr/bin/zabbix_check_smartmontools --health --device "$1"
 UserParameter=hardware.disk.smart.attributes[*],sudo /usr/bin/zabbix_check_smartmontools --device "$1" --attribute "$2"
-UserParameter=hardware.disk.smart.infos[*],sudo /usr/bin/zabbix_check_smartmontools --device "$1" --info "$2"
+UserParameter=hardware.disk.smart.info[*],sudo /usr/bin/zabbix_check_smartmontools --device "$1" --info "$2"
 

--- a/zabbix_templates/3.4-outdated/custom-os-linux-hardware.xml
+++ b/zabbix_templates/3.4-outdated/custom-os-linux-hardware.xml
@@ -409,7 +409,7 @@
                             <type>7</type>
                             <snmp_community/>
                             <snmp_oid/>
-                            <key>hardware.disk.smart.infos[{#BLOCKDEVICE},Device Model]</key>
+                            <key>hardware.disk.smart.info[{#BLOCKDEVICE},Device Model]</key>
                             <delay>1d</delay>
                             <history>90d</history>
                             <trends>0</trends>
@@ -451,7 +451,7 @@
                             <type>7</type>
                             <snmp_community/>
                             <snmp_oid/>
-                            <key>hardware.disk.smart.infos[{#BLOCKDEVICE},Serial Number]</key>
+                            <key>hardware.disk.smart.info[{#BLOCKDEVICE},Serial Number]</key>
                             <delay>1d</delay>
                             <history>90d</history>
                             <trends>0</trends>

--- a/zabbix_templates/3.4-outdated/documentation/custom-os-linux-hardware.html
+++ b/zabbix_templates/3.4-outdated/documentation/custom-os-linux-hardware.html
@@ -167,12 +167,12 @@
 <tr>
 <td>
 <p class="desc">Zabbix Agent (active)</p>
-</td><td>{#BLOCKDEVICE} Device model</td><td><tt>hardware.disk.smart.infos[{#BLOCKDEVICE},Device Model]</tt></td><td></td><td>1d</td><td>90d</td><td>0</td>
+</td><td>{#BLOCKDEVICE} Device model</td><td><tt>hardware.disk.smart.info[{#BLOCKDEVICE},Device Model]</tt></td><td></td><td>1d</td><td>90d</td><td>0</td>
 </tr>
 <tr>
 <td>
 <p class="desc">Zabbix Agent (active)</p>
-</td><td>{#BLOCKDEVICE} Serial Number</td><td><tt>hardware.disk.smart.infos[{#BLOCKDEVICE},Serial Number]</tt></td><td></td><td>1d</td><td>90d</td><td>0</td>
+</td><td>{#BLOCKDEVICE} Serial Number</td><td><tt>hardware.disk.smart.info[{#BLOCKDEVICE},Serial Number]</tt></td><td></td><td>1d</td><td>90d</td><td>0</td>
 </tr>
 </table>
 </body>

--- a/zabbix_templates/4.4-outdated/custom-os-linux-hardware.xml
+++ b/zabbix_templates/4.4-outdated/custom-os-linux-hardware.xml
@@ -171,7 +171,7 @@
                         <item_prototype>
                             <name>{#BLOCKDEVICE} Device model</name>
                             <type>ZABBIX_ACTIVE</type>
-                            <key>hardware.disk.smart.infos[{#BLOCKDEVICE},Device Model]</key>
+                            <key>hardware.disk.smart.info[{#BLOCKDEVICE},Device Model]</key>
                             <delay>1d</delay>
                             <trends>0</trends>
                             <value_type>CHAR</value_type>
@@ -185,7 +185,7 @@
                         <item_prototype>
                             <name>{#BLOCKDEVICE} Serial Number</name>
                             <type>ZABBIX_ACTIVE</type>
-                            <key>hardware.disk.smart.infos[{#BLOCKDEVICE},Serial Number]</key>
+                            <key>hardware.disk.smart.info[{#BLOCKDEVICE},Serial Number]</key>
                             <delay>1d</delay>
                             <trends>0</trends>
                             <value_type>CHAR</value_type>

--- a/zabbix_templates/4.4-outdated/documentation/custom-os-linux-hardware.html
+++ b/zabbix_templates/4.4-outdated/documentation/custom-os-linux-hardware.html
@@ -144,10 +144,10 @@
 <td>ZABBIX_ACTIVE</td><td>{#BLOCKDEVICE}: ID 199 UDMA_CRC_Error</td><td><tt>hardware.disk.smart.attributes[{#BLOCKDEVICE},UDMA_CRC_Error_Count]</tt></td><td></td><td>2h</td><td>1w</td><td></td>
 </tr>
 <tr>
-<td>ZABBIX_ACTIVE</td><td>{#BLOCKDEVICE} Device model</td><td><tt>hardware.disk.smart.infos[{#BLOCKDEVICE},Device Model]</tt></td><td></td><td>1d</td><td></td><td>0</td>
+<td>ZABBIX_ACTIVE</td><td>{#BLOCKDEVICE} Device model</td><td><tt>hardware.disk.smart.info[{#BLOCKDEVICE},Device Model]</tt></td><td></td><td>1d</td><td></td><td>0</td>
 </tr>
 <tr>
-<td>ZABBIX_ACTIVE</td><td>{#BLOCKDEVICE} Serial Number</td><td><tt>hardware.disk.smart.infos[{#BLOCKDEVICE},Serial Number]</tt></td><td></td><td>1d</td><td></td><td>0</td>
+<td>ZABBIX_ACTIVE</td><td>{#BLOCKDEVICE} Serial Number</td><td><tt>hardware.disk.smart.info[{#BLOCKDEVICE},Serial Number]</tt></td><td></td><td>1d</td><td></td><td>0</td>
 </tr>
 </table>
 </body>


### PR DESCRIPTION
Replaced `hardware.disk.smart.infos` everywhere by `hardware.disk.smart.info`.
Fixes #56